### PR TITLE
Map "can be mapped in future" geoms

### DIFF
--- a/sql/attributes_badgeoms.sql
+++ b/sql/attributes_badgeoms.sql
@@ -16,11 +16,22 @@ AND (geomsource <> 'dpr' OR geomsource <> 'dot' OR geomsource <> 'ddc')
 -- Remove from agency data
 UPDATE cpdb_dcpattributes
 SET geom = NULL
-WHERE maprojid IN (
-SELECT DISTINCT maprojid
-FROM dcp_cpdb_agencyverified
-WHERE (mappable = 'No - Can be in future'
-OR mappable = 'No - Can never be mapped')
+WHERE 
+(
+    (maprojid IN (
+        SELECT DISTINCT maprojid
+        FROM dcp_cpdb_agencyverified
+        WHERE mappable = 'No - Can never be mapped'
+        )
+    )
+OR 
+    (maprojid IN (
+        SELECT DISTINCT maprojid
+        FROM dcp_cpdb_agencyverified
+        WHERE mappable = 'No - Can be in future'
+        )
+    AND NOT geomsource IN ('dpr','dot','ddc','edc')
+    )
 )
 AND geom IS NOT NULL
 ;


### PR DESCRIPTION
#74 

Only NULL out geometries for records flagged as not mappable in dcp_cpdb_agencyverified if:
1) The mappable flag is 'No - Can never be mapped' or
2) The mappable flag is 'No - Can be in future' and the source is not 'dpr','dot','ddc', or 'edc'