### PR TITLE
removing push trigger for CI workflow 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  push:
+  # push:
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
This trigger will be removed after we accidentally built by updating census tracts. All builds should go through workflow dispatch from here on out to avoid accidental builds