### PR TITLE
outdated administrative boundary

### DIFF
--- a/sql/attributes_maprojid_censustracts.sql
+++ b/sql/attributes_maprojid_censustracts.sql
@@ -16,27 +16,17 @@ CREATE TABLE attributes_maprojid_censustracts AS (
   FROM (
     SELECT a.maprojid AS feature_id,
         'nta'::text AS admin_boundary_type,
-       b.ntacode::text AS admin_boundary_id
+       b.nta2020::text AS admin_boundary_id
       FROM cpdb_dcpattributes a,
        dcp_ct2020 b
     WHERE ST_Intersects(a.geom, b.wkb_geometry)
   ) b
   UNION ALL
-  SELECT c.*
-  FROM (
-    SELECT a.maprojid AS feature_id,
-        'puma'::text AS admin_boundary_type,
-       b.puma::text AS admin_boundary_id
-      FROM cpdb_dcpattributes a,
-       dcp_ct2020 b
-    WHERE ST_Intersects(a.geom, b.wkb_geometry)
-  ) c
-  UNION ALL
   SELECT d.*
   FROM (
     SELECT a.maprojid AS feature_id,
         'censtract'::text AS admin_boundary_type,
-       b.boroct2010::text AS admin_boundary_id
+       b.boroct2020::text AS admin_boundary_id
       FROM cpdb_dcpattributes a,
        dcp_ct2020 b
     WHERE ST_Intersects(a.geom, b.wkb_geometry)


### PR DESCRIPTION
address #90 the change the administrative boundary columns to match the new version of the table. 

## dcp_ct2020
this is the table involved in change. The columns changes are also specified in the issue. Since puma is removed entirely from the table, the spatial join clause is also removed. 