### PR TITLE
change version

### DIFF
--- a/version.env
+++ b/version.env
@@ -1,1 +1,1 @@
-ccp_v=fisa_2021
+ccp_v=fisa_2022


### PR DESCRIPTION
need to update the `version.env` file to 2022 to allow the export to have the correct filter. 

tested locally and the output table now has records. 