### PR TITLE
change building footprints to last working version

### DIFF
--- a/bash/01_dataloading.sh
+++ b/bash/01_dataloading.sh
@@ -20,7 +20,7 @@ import fdny_firecompanies &
 # Building and lot-level info
 import dcp_mappluto &
 import dcp_facilities &
-import doitt_buildingfootprints &
+import doitt_buildingfootprints 20220410 &
 
 # Projects
 import cpdb_capital_spending &


### PR DESCRIPTION
temporary fix to #97 to revert `doitt_buildingfootprints` to the last working version