### PR TITLE
CPDB 2022-V2: Update to latest datasets

### DIFF
--- a/bash/01_dataloading.sh
+++ b/bash/01_dataloading.sh
@@ -19,8 +19,8 @@ import fdny_firecompanies &
 
 # Building and lot-level info
 import dcp_mappluto &
-import dcp_facilities 20210315 &
-import doitt_buildingfootprints 20220410 &
+import dcp_facilities 20210811 &
+import doitt_buildingfootprints &
 
 # Projects
 import cpdb_capital_spending &

--- a/bash/05_export.sh
+++ b/bash/05_export.sh
@@ -18,6 +18,7 @@ mkdir -p output && (
     CSV_export cpdb_budgets &
     CSV_export cpdb_projects_spending_byyear &
     CSV_export ddc_capitalprojects_infrastructure &
+    CSV_export cpdb_dcpattributes &
     wait 
     echo 
     echo "export complete"

--- a/bash/05_export.sh
+++ b/bash/05_export.sh
@@ -17,6 +17,7 @@ mkdir -p output && (
     CSV_export cpdb_projects &
     CSV_export cpdb_budgets &
     CSV_export cpdb_projects_spending_byyear &
+    CSV_export ddc_capitalprojects_infrastructure &
     wait 
     echo 
     echo "export complete"

--- a/bash/05_export.sh
+++ b/bash/05_export.sh
@@ -17,8 +17,6 @@ mkdir -p output && (
     CSV_export cpdb_projects &
     CSV_export cpdb_budgets &
     CSV_export cpdb_projects_spending_byyear &
-    CSV_export ddc_capitalprojects_infrastructure &
-    CSV_export cpdb_dcpattributes &
     wait 
     echo 
     echo "export complete"

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -85,6 +85,9 @@ function import {
       cd $target_dir
       if [ "$acl" != "public-read" ] ; then
         mc cp spaces/edm-recipes/datasets/$name/$version/$name.sql $name.sql
+        echo "404 cannot read $name"
+        echo "dataset is access level $acl"
+      
       else
         curl -O $URL/datasets/$name/$version/$name.sql $name.sql
       fi


### PR DESCRIPTION
This PR is open to incorporate minor changes to the dataloading step to get the latest versions of doitt_buildingfootprints and dcp_facilities into the main branch for a full cpdb build. 

- Revert back to the "latest" version of doitt_buildingfootprints as the geometry issue has been fixed in open data
- Revert to the most recent published version of facdb - one outstanding question I have is why this was changed to the previous version in the last build of cpdb. This PR points to the august 2021 version as supposed to the march 2021 version.