### PR TITLE
Fix bug on convert lines to polygons step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
       - name: 01 dataloading
         run: ./cpdb.sh dataloading
       
-      - name: 02 Build Atrribute
+      - name: 02 Build Attribute
         run: ./cpdb.sh attribute
       
       - name: 03 Adminbounds

--- a/bash/02_build_attribute.sh
+++ b/bash/02_build_attribute.sh
@@ -152,7 +152,7 @@ echo
 
 # geometry cleaning -- lines to polygons and all geoms to multi
 echo 'Cleaning geometries: lines to polygons and geoms to multi'
-psql $BUILD_ENGINE -f sql/attributes_geomclean.sql
+psql $BUILD_ENGINE -f -q sql/attributes_geomclean.sql
 
 # remove faulty geometries	
 echo 'Removing bad geometries'	

--- a/bash/02_build_attribute.sh
+++ b/bash/02_build_attribute.sh
@@ -27,7 +27,7 @@ psql $BUILD_ENGINE -c "
         geomsource text, 
         geom geometry)"
 
-psql $BUILD_ENGINE -f sql/sprints.sql
+psql $BUILD_ENGINE -q -f sql/sprints.sql
 
 # update cpdb_dcpattributes with geoms from sprints
 echo 'Updating geometries from old sprints'

--- a/bash/02_build_attribute.sh
+++ b/bash/02_build_attribute.sh
@@ -152,7 +152,7 @@ echo
 
 # geometry cleaning -- lines to polygons and all geoms to multi
 echo 'Cleaning geometries: lines to polygons and geoms to multi'
-psql $BUILD_ENGINE -f -q sql/attributes_geomclean.sql
+psql $BUILD_ENGINE  -q  -f sql/attributes_geomclean.sql
 
 # remove faulty geometries	
 echo 'Removing bad geometries'	

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -85,8 +85,6 @@ function import {
       cd $target_dir
       if [ "$acl" != "public-read" ] ; then
         mc cp spaces/edm-recipes/datasets/$name/$version/$name.sql $name.sql
-        echo "404 cannot read $name"
-        echo "dataset is access level $acl"
       
       else
         curl -O $URL/datasets/$name/$version/$name.sql $name.sql

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -96,30 +96,6 @@ function import {
 }
 
 function CSV_export {
-  psql $BUILD_ENGINE  -c "\COPY (
-    SELECT * FROM $@
-  ) TO STDOUT DELIMITER ',' CSV HEADER;" > $@.csv
-}
-
-function SHP_export {
-  urlparse $BUILD_ENGINE
-  table=$1
-  geomtype=$2
-  name=${3:-$table}
-  mkdir -p $name &&(
-    cd $name
-    ogr2ogr -progress -f "ESRI Shapefile" $name.shp \
-        PG:"host=$BUILD_HOST user=$BUILD_USER port=$BUILD_PORT dbname=$BUILD_DB password=$BUILD_PWD" \
-        $table -nlt $geomtype
-      rm -f $name.shp.zip
-      zip -9 $name.shp.zip *
-      ls | grep -v $name.shp.zip | xargs rm
-  )
-  mv $name/$name.shp.zip $name.shp.zip
-  rm -rf $name
-}
-
-function CSV_export {
   local name=$1
   local output_name=${2:-$name}
   psql $BUILD_ENGINE  -c "\COPY (
@@ -128,6 +104,7 @@ function CSV_export {
 }
 
 function SHP_export {
+  urlparse $BUILD_ENGINE
   local table=$1
   local geomtype=$2
   local name=${3:-$table}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 sqlalchemy
 psycopg2-binary
 jinja2
+dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pandas
 sqlalchemy
 psycopg2-binary
 jinja2
-dotenv
+python-dotenv

--- a/sql/attributes_agencyverified_geoms.sql
+++ b/sql/attributes_agencyverified_geoms.sql
@@ -24,7 +24,8 @@ SET geom = ST_Centroid(b.wkb_geometry)
 FROM doitt_buildingfootprints b 
 WHERE a.bin::bigint::text = b.bin::bigint::text
 AND a.bin IS NOT NULL
-AND a.geom IS NULL;
+AND a.geom IS NULL
+AND a.bin::text <> '#REF!';
 
 -- add geom for projects based on bbl
 UPDATE dcp_cpdb_agencyverified a

--- a/sql/attributes_geomclean.sql
+++ b/sql/attributes_geomclean.sql
@@ -1,9 +1,20 @@
 --Update lines to be polygons
-UPDATE cpdb_dcpattributes
-SET geom=ST_Buffer(geom::geography, 15)::geometry
-WHERE ST_GeometryType(geom) = 'ST_MultiLineString';
+-- UPDATE cpdb_dcpattributes
+-- SET geom=ST_Buffer(geom::geography, 15)::geometry
+-- WHERE ST_GeometryType(geom) = 'ST_MultiLineString';
 
+
+do $$
+BEGIN
+    FOR i IN 1..(SELECT(count(maprojid)) from cpdb_dcpattributes) by 100 LOOP 
+        UPDATE cpdb_dcpattributes 
+        SET geom=ST_Buffer(geom::geography, 15)::geometry
+        WHERE ST_GeometryType(geom) = 'ST_MultiLineString' AND maprojid IN 
+        (SELECT maprojid from cpdb_dcpattributes WHERE
+         ST_GeometryType(geom) = 'ST_MultiLineString' LIMIT 100);
+    END LOOP; 
 --Update geom to be multi
 UPDATE cpdb_dcpattributes
 SET geom=ST_Multi(geom)
 WHERE ST_GeometryType(geom) in ('ST_Polygon', 'ST_Point');
+end; $$

--- a/sql/attributes_geomclean.sql
+++ b/sql/attributes_geomclean.sql
@@ -12,4 +12,4 @@ WHERE ST_GeometryType(geom) in ('ST_Polygon', 'ST_Point');
 --Make the geom valid
 UPDATE cpdb_dcpattributes
 SET geom=ST_MakeValid(geom)
-WHERE ST_IsValid(geom) = FALSE
+WHERE ST_IsValid(geom) = FALSE;

--- a/sql/attributes_geomclean.sql
+++ b/sql/attributes_geomclean.sql
@@ -8,8 +8,3 @@ WHERE ST_GeometryType(geom) = 'ST_MultiLineString';
 UPDATE cpdb_dcpattributes
 SET geom=ST_Multi(geom)
 WHERE ST_GeometryType(geom) in ('ST_Polygon', 'ST_Point');
-
---Make the geom valid
--- UPDATE cpdb_dcpattributes
--- SET geom=ST_MakeValid(geom)
--- WHERE ST_IsValid(geom) = FALSE;

--- a/sql/attributes_geomclean.sql
+++ b/sql/attributes_geomclean.sql
@@ -1,22 +1,23 @@
 --Update lines to be polygons
--- UPDATE cpdb_dcpattributes
--- SET geom=ST_Buffer(geom::geography, 15)::geometry
--- WHERE ST_GeometryType(geom) = 'ST_MultiLineString';
-
-
-do $$
-BEGIN
 UPDATE cpdb_dcpattributes SET geom = ST_SnapToGrid(geom, .001);
+UPDATE cpdb_dcpattributes
+SET geom=ST_Buffer(geom::geography, 15)::geometry
+WHERE ST_GeometryType(geom) = 'ST_MultiLineString';
 
-    FOR i IN 1..(SELECT(count(maprojid)) from cpdb_dcpattributes) by 100 LOOP 
-        UPDATE cpdb_dcpattributes 
-        SET geom=ST_Buffer(geom::geography, 15)::geometry
-        WHERE ST_GeometryType(geom) = 'ST_MultiLineString' AND maprojid IN 
-        (SELECT maprojid from cpdb_dcpattributes WHERE
-         ST_GeometryType(geom) = 'ST_MultiLineString' LIMIT 100);
-    END LOOP; 
+
+-- do $$
+-- BEGIN
+-- UPDATE cpdb_dcpattributes SET geom = ST_SnapToGrid(geom, .001);
+
+--     FOR i IN 1..(SELECT(count(maprojid)) from cpdb_dcpattributes) by 100 LOOP 
+--         UPDATE cpdb_dcpattributes 
+--         SET geom=ST_Buffer(geom::geography, 15)::geometry
+--         WHERE ST_GeometryType(geom) = 'ST_MultiLineString' AND maprojid IN 
+--         (SELECT maprojid from cpdb_dcpattributes WHERE
+--          ST_GeometryType(geom) = 'ST_MultiLineString' LIMIT 100);
+--     END LOOP; 
 --Update geom to be multi
 UPDATE cpdb_dcpattributes
 SET geom=ST_Multi(geom)
 WHERE ST_GeometryType(geom) in ('ST_Polygon', 'ST_Point');
-end; $$
+-- end; $$

--- a/sql/attributes_geomclean.sql
+++ b/sql/attributes_geomclean.sql
@@ -9,7 +9,6 @@ UPDATE cpdb_dcpattributes
 SET geom=ST_Multi(geom)
 WHERE ST_GeometryType(geom) in ('ST_Polygon', 'ST_Point');
 
-echo 'make geom valid'
 --Make the geom valid
 UPDATE cpdb_dcpattributes
 SET geom=ST_MakeValid(geom)

--- a/sql/attributes_geomclean.sql
+++ b/sql/attributes_geomclean.sql
@@ -4,20 +4,8 @@ UPDATE cpdb_dcpattributes
 SET geom=ST_Buffer(geom::geography, 15)::geometry
 WHERE ST_GeometryType(geom) = 'ST_MultiLineString';
 
-
--- do $$
--- BEGIN
--- UPDATE cpdb_dcpattributes SET geom = ST_SnapToGrid(geom, .001);
-
---     FOR i IN 1..(SELECT(count(maprojid)) from cpdb_dcpattributes) by 100 LOOP 
---         UPDATE cpdb_dcpattributes 
---         SET geom=ST_Buffer(geom::geography, 15)::geometry
---         WHERE ST_GeometryType(geom) = 'ST_MultiLineString' AND maprojid IN 
---         (SELECT maprojid from cpdb_dcpattributes WHERE
---          ST_GeometryType(geom) = 'ST_MultiLineString' LIMIT 100);
---     END LOOP; 
+ 
 --Update geom to be multi
 UPDATE cpdb_dcpattributes
 SET geom=ST_Multi(geom)
 WHERE ST_GeometryType(geom) in ('ST_Polygon', 'ST_Point');
--- end; $$

--- a/sql/attributes_geomclean.sql
+++ b/sql/attributes_geomclean.sql
@@ -6,6 +6,8 @@
 
 do $$
 BEGIN
+UPDATE cpdb_dcpattributes SET geom = ST_SnapToGrid(geom, .001);
+
     FOR i IN 1..(SELECT(count(maprojid)) from cpdb_dcpattributes) by 100 LOOP 
         UPDATE cpdb_dcpattributes 
         SET geom=ST_Buffer(geom::geography, 15)::geometry

--- a/sql/attributes_geomclean.sql
+++ b/sql/attributes_geomclean.sql
@@ -4,7 +4,6 @@ UPDATE cpdb_dcpattributes
 SET geom=ST_Buffer(geom::geography, 15)::geometry
 WHERE ST_GeometryType(geom) = 'ST_MultiLineString';
 
- 
 --Update geom to be multi
 UPDATE cpdb_dcpattributes
 SET geom=ST_Multi(geom)

--- a/sql/attributes_geomclean.sql
+++ b/sql/attributes_geomclean.sql
@@ -8,3 +8,9 @@ WHERE ST_GeometryType(geom) = 'ST_MultiLineString';
 UPDATE cpdb_dcpattributes
 SET geom=ST_Multi(geom)
 WHERE ST_GeometryType(geom) in ('ST_Polygon', 'ST_Point');
+
+echo 'make geom valid'
+--Make the geom valid
+UPDATE cpdb_dcpattributes
+SET geom=ST_MakeValid(geom)
+WHERE ST_IsValid(geom) = FALSE

--- a/sql/attributes_geomclean.sql
+++ b/sql/attributes_geomclean.sql
@@ -1,5 +1,5 @@
 --Update lines to be polygons
-UPDATE cpdb_dcpattributes SET geom = ST_SnapToGrid(geom, .001);
+UPDATE cpdb_dcpattributes SET geom = ST_SnapToGrid(geom, .00001) WHERE ST_GeometryType(geom) ='ST_MultiLineString';
 UPDATE cpdb_dcpattributes
 SET geom=ST_Buffer(geom::geography, 15)::geometry
 WHERE ST_GeometryType(geom) = 'ST_MultiLineString';
@@ -10,6 +10,6 @@ SET geom=ST_Multi(geom)
 WHERE ST_GeometryType(geom) in ('ST_Polygon', 'ST_Point');
 
 --Make the geom valid
-UPDATE cpdb_dcpattributes
-SET geom=ST_MakeValid(geom)
-WHERE ST_IsValid(geom) = FALSE;
+-- UPDATE cpdb_dcpattributes
+-- SET geom=ST_MakeValid(geom)
+-- WHERE ST_IsValid(geom) = FALSE;


### PR DESCRIPTION
# Fix convert lines to polygons
In [previous runs of the build workflow](https://github.com/NYCPlanning/db-cpdb/runs/6675767941?check_suite_focus=true) we were getting this error `psql:sql/attributes_geomclean.sql:4: ERROR:  GEOSBuffer: TopologyException: No forward edges found in buffer subgraph`
Googling the error led us to [this blog post](https://gis.stackexchange.com/questions/101639/postgis-st-buffer-breaks-because-of-no-forward-edges) which suggested implementing the PostGIS `ST_SnapToGrid` function. This did fix the issue,  you can see on [runs from the 109 branch](https://github.com/NYCPlanning/db-cpdb/runs/6698007112?check_suite_focus=true) that this error no longer occurs.

### Minor Upgrades
I made some other small upgrades while working with the build attribute step. 
1) Fixed spelling error in the name of the step in github actions
2) Replaced `frame.append()` with `pd.concat` in `attributes_maprojid_parkid`
3) Updated `attributes_maprojid_parkid` to use `dotenv` python package
4) Added -q flag to suppress `INSERT 0 1` messages that were filling up the logs in the github actions. It's much easier to navigate the logs now