### PR TITLE
update bucket to edm-publishing from edm-private

### DIFF
--- a/cpdb.sh
+++ b/cpdb.sh
@@ -40,7 +40,7 @@ function cpdb_archive {
 function cpdb_upload {
     local branchname=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
     local DATE=$(date "+%Y-%m-%d")
-    local SPACES="spaces/edm-private/db-cpdb/$branchname"
+    local SPACES="spaces/edm-publishing/db-cpdb/$branchname"
     local HASH=$(git describe --always)
     mc rm -r --force $SPACES/latest
     mc rm -r --force $SPACES/$DATE
@@ -64,7 +64,7 @@ function share {
             local branch=${1:-main}
             local version=${2:-latest}
             local file=${3:-output.zip}
-            mc share download spaces/edm-private/db-cpdb/$branch/$version/output/$file
+            mc share download spaces/edm-publishing/db-cpdb/$branch/$version/output/$file
         ;;
     esac
 }


### PR DESCRIPTION
This PR addresses issue #125.

In an effort to simplify our existing DigitalOcean folder structure and after the release of CPDB to the public, we decided to migrate `db-cpdb` from `edm-private` to `edm-publishing` (where we store a vast majority of our data products). This required copying over the established file structure from `edm-private/db-cpdb/main` to `edm-publishing/db-cpdb` and updating the the bucket path in this PR to point to `edm-publishing`.

In order to test that this change worked successfully, I ran a Github Action [here](https://github.com/NYCPlanning/db-cpdb/runs/8117591193?check_suite_focus=true#logs). The DigitalOcean output was reviewed to establish that the necessary files were uploaded to DO and that the established folder/file structure was in place. The outputs can be viewed [here](https://cloud.digitalocean.com/spaces/edm-publishing?i=266877&path=db-cpdb%2F)