### PR TITLE
Write versions of source data to output csv at time of import

### DIFF
--- a/bash/01_dataloading.sh
+++ b/bash/01_dataloading.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 source bash/config.sh
 
+# Create data_source_versions.csv
+init_versions_file
+
 # Reference tables
 psql $BUILD_ENGINE -f sql/_create.sql
 

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -76,6 +76,7 @@ function import {
   local acl=$(get_acl $name $version)
   local version=$(get_version $name $version $acl)
   local target_dir=$(pwd)/.library/datasets/$name/$version
+  local output_dir=$(pwd)/output
   # Download sql dump for the datasets from data library
   if [ -f $target_dir/$name.sql ]; then
     echo "✅ $name.sql exists in cache"
@@ -93,6 +94,13 @@ function import {
   fi
   # Loading into Database
   psql $BUILD_ENGINE -f $target_dir/$name.sql
+  echo "$name,$version" >> "$output_dir/source_data_versions.csv"
+}
+
+function init_versions_file {
+  mkdir -p output
+  rm -f output/source_data_versions.csv
+  echo "schema_name,v" >> output/source_data_versions.csv
 }
 
 function CSV_export {


### PR DESCRIPTION
Closes #131 

#131 references pluto as an example, but I went with a different approach as of this moment. In pluto, there's a [sql file](https://github.com/NYCPlanning/db-pluto/blob/main/pluto_build/sql/source_data_versions.sql). This sql gets called via psql at time of data export, selecting version number from each temporary sql table to dump it into a csv. Pro of this is that it happens at the same time as all the other data exporting, so separating out steps of pipeline in a logical grouping.

Downside is that it's a fair amount of code query version number explicitly, one at a time, when there's already a step of the pipeline where we explicitly get version number - at time of data loading/import. So here, I went ahead and just created and built that csv at time of import.